### PR TITLE
feat: add GitHub profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,8 @@ Rust           ░░░░░░░░░░░░░░░░░░░░░�
 ```
 
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com/?user=CarlosDanielDev&theme=tokyonight&hide_border=true&background=00000000" />
-    <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com/?user=CarlosDanielDev&theme=default&hide_border=true" />
-    <img src="https://streak-stats.demolab.com/?user=CarlosDanielDev&theme=tokyonight&hide_border=true" alt="GitHub Streak"/>
-  </picture>
+  <img src="https://img.shields.io/badge/Current_Streak-44_days-FF6B35?style=for-the-badge&logo=fire&logoColor=white" alt="Current Streak"/>
+  <img src="https://img.shields.io/badge/Longest_Streak-44_days-FF6B35?style=for-the-badge&logo=fire&logoColor=white" alt="Longest Streak"/>
 </p>
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -1,70 +1,179 @@
-<h1 align="center">Hey, I'm Carlos Daniel 👋</h1>
-<h3 align="center">Software Developer & Indie Maker from São Paulo, Brazil</h3>
+<h1 align="center">
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&weight=600&size=28&duration=4000&pause=1000&color=70A5FD&center=true&vCenter=true&random=false&width=600&lines=Hey%2C+I'm+Carlos+Daniel+%F0%9F%91%8B;Software+Developer+%26+Indie+Maker;8%2B+Years+Building+Software" alt="Typing SVG" />
+</h1>
 
 <p align="center">
-  From PHP CRUDs in 2017 to Swift iOS apps and Rust APIs in 2025.<br/>
-  8+ years building across the full stack, embedded hardware, and mobile.
+  <a href="https://carlosdaniel.dev"><img src="https://img.shields.io/badge/Portfolio-carlosdaniel.dev-70A5FD?style=for-the-badge&logo=google-chrome&logoColor=white" alt="Portfolio"/></a>
+  <a href="https://x.com/carlosdevdaniel"><img src="https://img.shields.io/badge/X-@carlosdevdaniel-000000?style=for-the-badge&logo=x&logoColor=white" alt="X"/></a>
+  <a href="https://linkedin.com/in/carlos-daniel-3a5574142"><img src="https://img.shields.io/badge/LinkedIn-Carlos%20Daniel-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn"/></a>
+  <a href="mailto:contact@carlosdaniel.dev"><img src="https://img.shields.io/badge/Email-contact@carlosdaniel.dev-EA4335?style=for-the-badge&logo=gmail&logoColor=white" alt="Email"/></a>
 </p>
 
----
+<br/>
 
-### 📌 Current Role
+## 👨‍💻 About Me
 
-- 💻 **Software Engineer at [Kyte](https://kyte.com)** — Building products that help small businesses thrive
-- 🍎 **Indie Maker** — Shipping iOS apps on the App Store, building in public
+```yaml
+name: Carlos Daniel
+location: São Paulo, Brazil
+current_role: Software Engineer @ Kyte
+side_quest: Indie iOS Maker — 3 apps on the App Store
+editor: Neovim (LazyVim)
+journey: PHP CRUDs (2017) → Full Stack → Mobile → Hardware → Indie Maker
+```
 
----
+<br/>
 
-### 🚀 Indie Apps
+## 🍎 Indie Apps
 
-| App | Description | Status |
-|-----|------------|--------|
-| **[BlockZero](https://apps.apple.com/us/app/block-zero/id6747401298)** | 2048 reimagined — 5 game modes, 8 themes, 43 milestones | ✅ Published |
-| **[AquaBrew](https://apps.apple.com/us/app/aquabrew/id6758528433)** | Scan water labels to check SCA coffee standards | ✅ Published |
-| **[Warranty Checker](https://apps.apple.com/us/app/warranty-checker/id6759304054)** | Scan receipts & warranty cards, get expiration reminders | ✅ Published |
-| **Lucid Mate** | Real-time multiplayer chess with Socket.IO | 🔜 Coming Soon |
+<table>
+  <tr>
+    <td align="center" width="25%">
+      <strong>BlockZero</strong><br/>
+      <sub>2048 Reimagined</sub><br/><br/>
+      <a href="https://apps.apple.com/us/app/block-zero/id6747401298">
+        <img src="https://img.shields.io/badge/App_Store-Published-000000?style=for-the-badge&logo=app-store&logoColor=white" alt="App Store"/>
+      </a>
+    </td>
+    <td align="center" width="25%">
+      <strong>AquaBrew</strong><br/>
+      <sub>Water quality for coffee</sub><br/><br/>
+      <a href="https://apps.apple.com/us/app/aquabrew/id6758528433">
+        <img src="https://img.shields.io/badge/App_Store-Published-000000?style=for-the-badge&logo=app-store&logoColor=white" alt="App Store"/>
+      </a>
+    </td>
+    <td align="center" width="25%">
+      <strong>Warranty Checker</strong><br/>
+      <sub>Scan. Track. Never Forget.</sub><br/><br/>
+      <a href="https://apps.apple.com/us/app/warranty-checker/id6759304054">
+        <img src="https://img.shields.io/badge/App_Store-Published-000000?style=for-the-badge&logo=app-store&logoColor=white" alt="App Store"/>
+      </a>
+    </td>
+    <td align="center" width="25%">
+      <strong>Lucid Mate</strong><br/>
+      <sub>Real-time multiplayer chess</sub><br/><br/>
+      <img src="https://img.shields.io/badge/Status-Coming_Soon-yellow?style=for-the-badge" alt="Coming Soon"/>
+    </td>
+  </tr>
+</table>
 
----
+<br/>
 
-### 🔧 What I Build With
+## 🛠️ Tech Stack
 
-#### Languages & Frameworks
-**JavaScript** · **TypeScript** · **Swift** · **Rust** · **C++** · **Lua** · **Elixir** · **Python** · **PHP**
+<details open>
+<summary><strong>Languages</strong></summary>
+<br/>
 
-#### Mobile & Frontend
-**React** · **React Native** · **SwiftUI** · **Next.js**
+![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
+![JavaScript](https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E)
+![Swift](https://img.shields.io/badge/swift-F54A2A?style=for-the-badge&logo=swift&logoColor=white)
+![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=for-the-badge&logo=rust&logoColor=white)
+![C++](https://img.shields.io/badge/c++-%2300599C.svg?style=for-the-badge&logo=c%2B%2B&logoColor=white)
+![Lua](https://img.shields.io/badge/lua-%232C2D72.svg?style=for-the-badge&logo=lua&logoColor=white)
+![Elixir](https://img.shields.io/badge/elixir-%234B275F.svg?style=for-the-badge&logo=elixir&logoColor=white)
+![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)
+![PHP](https://img.shields.io/badge/php-%23777BB4.svg?style=for-the-badge&logo=php&logoColor=white)
 
-#### Backend & Infrastructure
-**Node.js** · **Express** · **Firebase** · **MongoDB** · **PostgreSQL** · **Docker**
+</details>
 
-#### Embedded & Hardware
-**ESP32** · **M5Stick** · **Arduino** · **RFID/NFC**
+<details open>
+<summary><strong>Frontend & Mobile</strong></summary>
+<br/>
 
----
+![React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)
+![React Native](https://img.shields.io/badge/react_native-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)
+![SwiftUI](https://img.shields.io/badge/SwiftUI-FA7343?style=for-the-badge&logo=swift&logoColor=white)
+![Next.js](https://img.shields.io/badge/next.js-000000?style=for-the-badge&logo=next.js&logoColor=white)
 
-### ⚡ Highlights
+</details>
 
-- 🔩 **Hardware Hacker** — ESP32 and M5Stick projects: RFID card readers, NFC tools, hardware mouse jigglers → [copyrfid](https://github.com/CarlosDanielDev/copyrfid)
-- ✏️ **Neovim Power User** — Author of [discipline.nvim](https://github.com/CarlosDanielDev/discipline.nvim) plugin and the **saopaulo-night** color theme. Full LazyVim setup as daily driver
-- 🌐 **Polyglot Developer** — Shipping production code across 14 languages
-- 🏗️ **Clean Architecture Enthusiast** — DDD, Object Calisthenics, TDD
+<details open>
+<summary><strong>Backend & Infrastructure</strong></summary>
+<br/>
 
----
+![Node.js](https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white)
+![Express.js](https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB)
+![Firebase](https://img.shields.io/badge/firebase-%23039BE5.svg?style=for-the-badge&logo=firebase)
+![MongoDB](https://img.shields.io/badge/MongoDB-%234ea94b.svg?style=for-the-badge&logo=mongodb&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/postgres-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white)
+![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
 
-### 📊 GitHub Stats
+</details>
+
+<details open>
+<summary><strong>Embedded & Tools</strong></summary>
+<br/>
+
+![Arduino](https://img.shields.io/badge/-Arduino-00979D?style=for-the-badge&logo=Arduino&logoColor=white)
+![Neovim](https://img.shields.io/badge/NeoVim-%2357A143.svg?style=for-the-badge&logo=neovim&logoColor=white)
+![Git](https://img.shields.io/badge/git-%23F05033.svg?style=for-the-badge&logo=git&logoColor=white)
+
+</details>
+
+<br/>
+
+## ⚡ Highlights
+
+<table>
+  <tr>
+    <td>🔩</td>
+    <td>
+      <strong>Hardware Hacker</strong><br/>
+      ESP32 & M5Stick projects — RFID card readers, NFC tools, hardware mouse jigglers<br/>
+      <a href="https://github.com/CarlosDanielDev/copyrfid">→ copyrfid</a>
+    </td>
+  </tr>
+  <tr>
+    <td>✏️</td>
+    <td>
+      <strong>Neovim Power User</strong><br/>
+      Author of <a href="https://github.com/CarlosDanielDev/discipline.nvim">discipline.nvim</a> plugin and the <strong>saopaulo-night</strong> color theme. Full LazyVim daily driver.
+    </td>
+  </tr>
+  <tr>
+    <td>🌐</td>
+    <td>
+      <strong>Polyglot Developer</strong><br/>
+      Shipping production code across 14 languages — from TypeScript to Rust to C++
+    </td>
+  </tr>
+  <tr>
+    <td>🏗️</td>
+    <td>
+      <strong>Clean Architecture</strong><br/>
+      DDD, Object Calisthenics, TDD — architecture matters as much as the code
+    </td>
+  </tr>
+</table>
+
+<br/>
+
+## 📊 GitHub Stats
 
 <p align="center">
-  <img src="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&count_private=true" alt="GitHub Stats" height="165"/>
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true" alt="Top Languages" height="165"/>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&count_private=true&bg_color=00000000" />
+    <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=default&hide_border=true&count_private=true" />
+    <img height="165" src="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&count_private=true" alt="GitHub Stats"/>
+  </picture>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true&bg_color=00000000" />
+    <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=default&hide_border=true" />
+    <img height="165" src="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true" alt="Top Languages"/>
+  </picture>
 </p>
 
----
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://streak-stats.demolab.com/?user=CarlosDanielDev&theme=tokyonight&hide_border=true&background=00000000" />
+    <source media="(prefers-color-scheme: light)" srcset="https://streak-stats.demolab.com/?user=CarlosDanielDev&theme=default&hide_border=true" />
+    <img src="https://streak-stats.demolab.com/?user=CarlosDanielDev&theme=tokyonight&hide_border=true" alt="GitHub Streak"/>
+  </picture>
+</p>
 
-### 📩 Let's Connect
+<br/>
 
-<p align="left">
-  <a href="https://carlosdaniel.dev" target="_blank"><img src="https://img.shields.io/badge/Portfolio-carlosdaniel.dev-blue?style=flat-square&logo=google-chrome&logoColor=white" alt="Portfolio"/></a>
-  <a href="https://x.com/carlosdevdaniel" target="_blank"><img src="https://img.shields.io/badge/Twitter/X-@carlosdevdaniel-black?style=flat-square&logo=x&logoColor=white" alt="Twitter/X"/></a>
-  <a href="https://linkedin.com/in/carlos-daniel-3a5574142" target="_blank"><img src="https://img.shields.io/badge/LinkedIn-Carlos%20Daniel-blue?style=flat-square&logo=linkedin&logoColor=white" alt="LinkedIn"/></a>
-  <a href="mailto:contact@carlosdaniel.dev"><img src="https://img.shields.io/badge/Email-contact@carlosdaniel.dev-red?style=flat-square&logo=gmail&logoColor=white" alt="Email"/></a>
+<p align="center">
+  <img src="https://komarev.com/ghpvc/?username=CarlosDanielDev&color=70A5FD&style=flat-square&label=Profile+Views" alt="Profile views"/>
 </p>

--- a/README.md
+++ b/README.md
@@ -152,17 +152,23 @@ journey: PHP CRUDs (2017) → Full Stack → Mobile → Hardware → Indie Maker
 ## 📊 GitHub Stats
 
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true&hide=issues&bg_color=00000000" />
-    <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=default&hide_border=true&include_all_commits=true&count_private=true&hide=issues" />
-    <img height="165" src="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true&hide=issues" alt="GitHub Stats"/>
-  </picture>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true&hide=css,html,shell&langs_count=8&bg_color=00000000" />
-    <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=default&hide_border=true&hide=css,html,shell&langs_count=8" />
-    <img height="165" src="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true&hide=css,html,shell&langs_count=8" alt="Top Languages"/>
-  </picture>
+  <img src="https://img.shields.io/badge/Contributions-2,543_this_year-70A5FD?style=for-the-badge&logo=github&logoColor=white" alt="Contributions"/>
+  <img src="https://img.shields.io/badge/Total_Repos-182_(incl._private)-70A5FD?style=for-the-badge&logo=github&logoColor=white" alt="Repos"/>
+  <img src="https://img.shields.io/badge/Stars-71-70A5FD?style=for-the-badge&logo=github&logoColor=white" alt="Stars"/>
+  <img src="https://img.shields.io/badge/Since-2017-70A5FD?style=for-the-badge&logo=github&logoColor=white" alt="Since"/>
 </p>
+
+**Languages across all repos** (public + private, excluding forks):
+
+```text
+Swift          ████████████████░░░░░░░░░░░░░░░░░░░░░░░░░  34.3%
+TypeScript     ███████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░  33.4%
+JavaScript     █████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  28.6%
+C++            █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0.7%
+Elixir         ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0.3%
+Lua            ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0.2%
+Rust           ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0.2%
+```
 
 <p align="center">
   <picture>

--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ journey: PHP CRUDs (2017) → Full Stack → Mobile → Hardware → Indie Maker
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&count_private=true&bg_color=00000000" />
-    <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=default&hide_border=true&count_private=true" />
-    <img height="165" src="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&count_private=true" alt="GitHub Stats"/>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true&hide=issues&bg_color=00000000" />
+    <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=default&hide_border=true&include_all_commits=true&count_private=true&hide=issues" />
+    <img height="165" src="https://github-readme-stats.vercel.app/api?username=CarlosDanielDev&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true&hide=issues" alt="GitHub Stats"/>
   </picture>
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true&bg_color=00000000" />
-    <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=default&hide_border=true" />
-    <img height="165" src="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true" alt="Top Languages"/>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true&hide=css,html,shell&langs_count=8&bg_color=00000000" />
+    <source media="(prefers-color-scheme: light)" srcset="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=default&hide_border=true&hide=css,html,shell&langs_count=8" />
+    <img height="165" src="https://github-readme-stats.vercel.app/api/top-langs/?username=CarlosDanielDev&layout=compact&theme=tokyonight&hide_border=true&hide=css,html,shell&langs_count=8" alt="Top Languages"/>
   </picture>
 </p>
 


### PR DESCRIPTION
## Summary
- Add polished GitHub profile README with animated typing header, shields.io badges, and collapsible tech stack sections
- Showcase 3 published iOS apps (BlockZero, AquaBrew, Warranty Checker) with App Store links
- Include real GitHub stats fetched via GraphQL API (2,543 contributions, 182 repos, 71 stars, 44-day streak)
- Accurate language distribution from all 138 non-fork repos (Swift 34.3%, TypeScript 33.4%, JavaScript 28.6%)
- No reliance on third-party stats services (github-readme-stats, streak-stats) — all data hardcoded from API

## Test plan
- [ ] Verify README renders correctly on GitHub profile page
- [ ] Confirm all App Store links open correctly
- [ ] Check badges render properly (shields.io, typing SVG, profile views)
- [ ] Verify social links (portfolio, X, LinkedIn, email)

🤖 Generated with [Claude Code](https://claude.com/claude-code)